### PR TITLE
Added logic to process new date added from text box

### DIFF
--- a/src/Dnet.Blazor/Components/DatePicker/DnetDatePicker.razor
+++ b/src/Dnet.Blazor/Components/DatePicker/DnetDatePicker.razor
@@ -148,28 +148,29 @@
 
             EditContext.OnFieldChanged += async (data, eventArgs) =>
             {
-                var curDay = DateTime.Parse(CurrentValue);
-                if (_selectedDay.DayNumber != curDay.Day ||
-                    _selectedDay.Month != curDay.Month || 
-                    _selectedDay.Year != curDay.Year)
-                {
-                    var newDay = new CalendarDay();
-                    newDay.DayNumber = curDay.Day;
-                    newDay.Month = curDay.Month;
-                    newDay.Year = curDay.Year;
-                    
-                    await HandleDaySelectedAsync(newDay);
-                }
-                
                 _messageStore.Clear(FieldIdentifier);
 
-                DateTime selectedDay;
+                DateTime curDay;
                 
-                if (!DateTime.TryParseExact(CurrentValue, Formats, CultureInfo.InvariantCulture, DateTimeStyles.None, out selectedDay))
+                if (!DateTime.TryParseExact(CurrentValue, Formats, CultureInfo.InvariantCulture, DateTimeStyles.None, out curDay))
                 {
                     await OnError.InvokeAsync($"Invalid Date format. valid formats: {string.Join(", ", Formats)}");
 
                     _messageStore.Add(FieldIdentifier, $"Invalid Date format. valid formats: {string.Join(", ", Formats)}");
+                }
+                else
+                {
+                    if (_selectedDay.DayNumber != curDay.Day ||
+                        _selectedDay.Month != curDay.Month || 
+                        _selectedDay.Year != curDay.Year)
+                    {
+                        var newDay = new CalendarDay();
+                        newDay.DayNumber = curDay.Day;
+                        newDay.Month = curDay.Month;
+                        newDay.Year = curDay.Year;
+                    
+                        await HandleDaySelectedAsync(newDay);
+                    }
                 }
 
                 if (_formEventService is not null) _formEventService.RaiseCurrentValue(CurrentValueAsString);

--- a/src/Dnet.Blazor/Components/DatePicker/DnetDatePicker.razor
+++ b/src/Dnet.Blazor/Components/DatePicker/DnetDatePicker.razor
@@ -148,9 +148,23 @@
 
             EditContext.OnFieldChanged += async (data, eventArgs) =>
             {
+                var curDay = DateTime.Parse(CurrentValue);
+                if (_selectedDay.DayNumber != curDay.Day ||
+                    _selectedDay.Month != curDay.Month || 
+                    _selectedDay.Year != curDay.Year)
+                {
+                    var newDay = new CalendarDay();
+                    newDay.DayNumber = curDay.Day;
+                    newDay.Month = curDay.Month;
+                    newDay.Year = curDay.Year;
+                    
+                    await HandleDaySelectedAsync(newDay);
+                }
+                
                 _messageStore.Clear(FieldIdentifier);
 
                 DateTime selectedDay;
+                
                 if (!DateTime.TryParseExact(CurrentValue, Formats, CultureInfo.InvariantCulture, DateTimeStyles.None, out selectedDay))
                 {
                     await OnError.InvokeAsync($"Invalid Date format. valid formats: {string.Join(", ", Formats)}");


### PR DESCRIPTION
DnetDatePicker is not actually binding the value written in the textbox, only the value associated to the date selected in the calendar. This fixes the issue by calling HandleDaySelectedAsync in the onFieldChanged only when the date has changed from the previous one.